### PR TITLE
Promnet

### DIFF
--- a/prometheus-net/MetricServer.cs
+++ b/prometheus-net/MetricServer.cs
@@ -14,10 +14,14 @@ namespace Prometheus
         private static readonly string ProtoHeaderNoSpace = PROTO_HEADER.Replace(" ", "");
         private readonly ICollectorRegistry _registry;
 
-        public MetricServer(int port, string url = "metrics/", ICollectorRegistry registry = null)
+        public MetricServer(int port, string url = "metrics/", ICollectorRegistry registry = null) : this("+", port, url, registry)
+        {
+        }
+
+        public MetricServer(string hostname, int port, string url = "metrics/", ICollectorRegistry registry = null)
         {
             _registry = registry ?? DefaultCollectorRegistry.Instance;
-            _httpListener.Prefixes.Add(string.Format("http://+:{0}/{1}", port, url));
+            _httpListener.Prefixes.Add(string.Format("http://{0}:{1}/{2}", hostname, port, url));
             if (_registry == DefaultCollectorRegistry.Instance)
             {
                 DefaultCollectorRegistry.Instance.RegisterStandardPerfCounters();

--- a/tester/Program.cs
+++ b/tester/Program.cs
@@ -8,7 +8,7 @@ namespace tester
     {
         static void Main(string[] args)
         {
-            var metricServer = new MetricServer(port: 1234);
+            var metricServer = new MetricServer(hostname:"localhost", port: 1234);
             metricServer.Start();
 
             var counter = Metrics.CreateCounter("myCounter", "help text", labelNames: new []{ "method", "endpoint"});


### PR DESCRIPTION
This change allows specifying an explicit hostname to MetricServer. The use case is to pass 'localhost' to allow the embedded HttpListener to run without administrator privileges.

Also changed the collector registry to use ConcurrentDictionary rather than explicit locks.