### PR TITLE
Default collector changes

### DIFF
--- a/prometheus-net/Advanced/DotNetStatsCollector.cs
+++ b/prometheus-net/Advanced/DotNetStatsCollector.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Prometheus.Advanced
+{
+    /// <summary>
+    /// Collects metrics on .net without performance counters
+    /// </summary>
+    public class DotNetStatsCollector : IOnDemandCollector
+    {
+        private readonly Process _process;
+        private Counter _perfErrors;
+        private readonly List<Counter.Child> _collectionCounts = new List<Counter.Child>();
+        private Gauge _totalMemory;
+        private Gauge _virtualMemorySize;
+        private Gauge _workingSet;
+        private Gauge _privateMemorySize;
+        
+        public DotNetStatsCollector()
+        {
+            _process = Process.GetCurrentProcess();
+        }
+        
+        public void RegisterMetrics()
+        {
+            var collectionCountsParent = Metrics.CreateCounter("dotnet_collection_count_total", "GC collection count", new []{"generation"});
+            
+            for (var gen = 0; gen <= GC.MaxGeneration; gen++)
+            {
+                _collectionCounts.Add(collectionCountsParent.Labels(gen.ToString()));
+            }
+
+            _virtualMemorySize = Metrics.CreateGauge("process_virtual_bytes", "Process virtual memory size");
+            _workingSet = Metrics.CreateGauge("process_working_set", "Process working set");
+            _privateMemorySize = Metrics.CreateGauge("process_private_bytes", "Process private memory size");
+            _totalMemory = Metrics.CreateGauge("dotnet_totalmemory", "Total known allocated memory");
+            _perfErrors = Metrics.CreateCounter("dotnet_collection_errors_total", "Total number of errors that occured during collections");
+        }
+
+        public void UpdateMetrics()
+        {
+            try
+            {
+                for (var gen = 0; gen <= GC.MaxGeneration; gen++)
+                {
+                    var collectionCount = _collectionCounts[gen];
+                    collectionCount.Inc(GC.CollectionCount(gen) - collectionCount.Value);
+                }
+
+                _totalMemory.Set(GC.GetTotalMemory(false));
+                _virtualMemorySize.Set(_process.VirtualMemorySize64);
+                _workingSet.Set(_process.WorkingSet64);
+                _privateMemorySize.Set(_process.PrivateMemorySize64);
+            }
+            catch (Exception)
+            {
+                _perfErrors.Inc();
+            }
+        }
+    }
+}

--- a/prometheus-net/Advanced/IOnDemandCollector.cs
+++ b/prometheus-net/Advanced/IOnDemandCollector.cs
@@ -1,0 +1,8 @@
+﻿namespace Prometheus.Advanced
+{
+    public interface IOnDemandCollector
+    {
+        void RegisterMetrics();
+        void UpdateMetrics();
+    }
+}

--- a/prometheus-net/Advanced/PerfCounterCollector.cs
+++ b/prometheus-net/Advanced/PerfCounterCollector.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Prometheus.Advanced.DataContracts;
 
 namespace Prometheus.Advanced
 {
     /// <summary>
     /// Collects metrics on standard Performance Counters
     /// </summary>
-    public class PerfCounterCollector : ICollector
+    public class PerfCounterCollector : IOnDemandCollector
     {
         private const string MemCat = ".NET CLR Memory";
         private const string ProcCat = "Process";
@@ -44,7 +43,6 @@ namespace Prometheus.Advanced
 
         public PerfCounterCollector()
         {
-            Name = "performanceCounters";
             Process currentProcess = Process.GetCurrentProcess();
             _instanceName = currentProcess.ProcessName;
             if (IsLinux())
@@ -54,23 +52,8 @@ namespace Prometheus.Advanced
             }
         }
 
-        public void RegisterStandardPerfCounters()
+        private void RegisterPerfCounter(string category, string name)
         {
-            for (int i = 0; i < StandardPerfCounters.Length; i += 2)
-            {
-                var category = StandardPerfCounters[i];
-                var name = StandardPerfCounters[i + 1];
-
-                RegisterPerfCounter(category, name);
-            }
-
-            _perfErrors = Metrics.CreateCounter("performance_counter_errors_total",
-                "Total number of errors that occured during performance counter collections");
-        }
-
-        public void RegisterPerfCounter(string category, string name)
-        {
-            //Gauge.Child labelledMetric = Metrics.CreateGauge(GetName(category, name), GetHelp(name), "process").Labels(_processName);
             Gauge gauge = Metrics.CreateGauge(GetName(category, name), GetHelp(name));
             _collectors.Add(Tuple.Create(gauge, new PerformanceCounter(category, name, _instanceName)));
         }
@@ -90,9 +73,22 @@ namespace Prometheus.Advanced
             return name.Replace("%", "pct").Replace(" ", "_").Replace(".", "dot").ToLowerInvariant();
         }
 
-        public MetricFamily Collect()
+        public void RegisterMetrics()
         {
-            //update existing counters during a collect call
+            for (int i = 0; i < StandardPerfCounters.Length; i += 2)
+            {
+                var category = StandardPerfCounters[i];
+                var name = StandardPerfCounters[i + 1];
+
+                RegisterPerfCounter(category, name);
+            }
+
+            _perfErrors = Metrics.CreateCounter("performance_counter_errors_total",
+                "Total number of errors that occured during performance counter collections");
+        }
+
+        public void UpdateMetrics()
+        {
             foreach (var collector in _collectors)
             {
                 try
@@ -104,16 +100,6 @@ namespace Prometheus.Advanced
                     _perfErrors.Inc();
                 }
             }
-
-            //the way this collector is registered on DefaultCollectorRegistry ensures that this is the very first Collector collected
-            //so by the time the collectors registered in the _collectors list are collected they will all be up-to-date
-            //this works but a bit hacky...
-
-            //don't return anything - this will be dropped by the registry...
-            return null;
         }
-
-        public string Name { get; private set; }
-        public string[] LabelNames { get {return new string[0];} }
     }
 }

--- a/prometheus-net/MetricServer.cs
+++ b/prometheus-net/MetricServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Reactive.Concurrency;
@@ -9,22 +10,28 @@ namespace Prometheus
 {
     public class MetricServer
     {
+        public event Action PreCollect;
         private const string PROTO_HEADER = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
         private readonly HttpListener _httpListener = new HttpListener();
         private static readonly string ProtoHeaderNoSpace = PROTO_HEADER.Replace(" ", "");
         private readonly ICollectorRegistry _registry;
-
-        public MetricServer(int port, string url = "metrics/", ICollectorRegistry registry = null) : this("+", port, url, registry)
+        
+        public MetricServer(int port, IEnumerable<IOnDemandCollector> standardCollectors = null, string url = "metrics/", ICollectorRegistry registry = null) : this("+", port, standardCollectors, url, registry)
         {
         }
 
-        public MetricServer(string hostname, int port, string url = "metrics/", ICollectorRegistry registry = null)
+        public MetricServer(string hostname, int port, IEnumerable<IOnDemandCollector> standardCollectors = null, string url = "metrics/", ICollectorRegistry registry = null)
         {
             _registry = registry ?? DefaultCollectorRegistry.Instance;
             _httpListener.Prefixes.Add(string.Format("http://{0}:{1}/{2}", hostname, port, url));
             if (_registry == DefaultCollectorRegistry.Instance)
             {
-                DefaultCollectorRegistry.Instance.RegisterStandardPerfCounters();
+                // Default to perf counter collectors if none speified
+                // For no collectors, pass an empty collection
+                if (standardCollectors == null)
+                    standardCollectors = new[] {new PerfCounterCollector()};
+
+                DefaultCollectorRegistry.Instance.RegisterOnDemandCollectors(standardCollectors);
             }
         }
 
@@ -51,6 +58,9 @@ namespace Prometheus
             }
 
             response.AddHeader("Content-Type", type);
+
+            if (PreCollect != null)
+                PreCollect();
 
             var collected = _registry.CollectAll();
             using (var outputStream = response.OutputStream)

--- a/prometheus-net/MetricServer.cs
+++ b/prometheus-net/MetricServer.cs
@@ -10,7 +10,6 @@ namespace Prometheus
 {
     public class MetricServer
     {
-        public event Action PreCollect;
         private const string PROTO_HEADER = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
         private readonly HttpListener _httpListener = new HttpListener();
         private static readonly string ProtoHeaderNoSpace = PROTO_HEADER.Replace(" ", "");
@@ -58,9 +57,6 @@ namespace Prometheus
             }
 
             response.AddHeader("Content-Type", type);
-
-            if (PreCollect != null)
-                PreCollect();
 
             var collected = _registry.CollectAll();
             using (var outputStream = response.OutputStream)

--- a/prometheus-net/prometheus-net.csproj
+++ b/prometheus-net/prometheus-net.csproj
@@ -52,6 +52,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Advanced\Child.cs" />
+    <Compile Include="Advanced\DotNetStatsCollector.cs" />
+    <Compile Include="Advanced\IOnDemandCollector.cs" />
     <Compile Include="Advanced\PerfCounterCollector.cs" />
     <Compile Include="Counter.cs" />
     <Compile Include="Advanced\DataContracts.cs" />


### PR DESCRIPTION
Allow specifying alternative default collectors (or none).
Implement some process/.net metrics that do not rely on performance counters.

My main use case is to avoid relying on performance counters for metrics, which has proven problematic in practice on some of our servers. It seems this is a common problem: http://ayende.com/blog/165217/performance-counters-sucks

I have written an alternative default collector and made it possible to use this instead. By default the existing perf counter based metrics will continue to be used.