### PR TITLE
Generalise scraping so it can be called externally without using the embedded http handler

### DIFF
--- a/prometheus-net/ScrapeHandler.cs
+++ b/prometheus-net/ScrapeHandler.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Prometheus.Internal;
+
+namespace Prometheus
+{
+    internal class ScrapeHandler
+    {
+        private const string ProtoContentType = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
+        private const string TextContentType = "text/plain; version=0.0.4";
+        private const string ProtoAcceptType = "application/vnd.google.protobuf";
+
+        public string ProcessScrapeRequest(
+            IEnumerable<Advanced.DataContracts.MetricFamily> collected, 
+            IEnumerable<string> acceptHeaders, 
+            Stream outputStream)
+        {
+            if (ProtobufAccepted(acceptHeaders))
+            {
+                ProtoFormatter.Format(outputStream, collected);
+                return ProtoContentType;
+            }
+            else
+            {
+                AsciiFormatter.Format(outputStream, collected);
+                return TextContentType;
+            }
+        }
+
+        private static bool ProtobufAccepted(IEnumerable<string> acceptTypesHeader)
+        {
+            if (acceptTypesHeader == null)
+                return false;
+
+            var splitParams = acceptTypesHeader.Select(_ => _.Split(';'));
+            var acceptTypes = splitParams.Select(_ => _.First()).ToList();
+
+            return acceptTypes.Any(_ => _.Equals(ProtoAcceptType, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/prometheus-net/prometheus-net.csproj
+++ b/prometheus-net/prometheus-net.csproj
@@ -70,6 +70,7 @@
     <Compile Include="MetricServer.cs" />
     <Compile Include="Advanced\DefaultCollectorRegistry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScrapeHandler.cs" />
     <Compile Include="Summary.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The use case here is to allow the client to be embedded in web apps that have their own http handlers, without having to open up a separate port.

To do this the MetricServer.Start method would not be called, instead ProcessScrapeRequest would be called by the hosting framework when the /metrics path is requested.