### PR TITLE
Fix header writing order

### DIFF
--- a/prometheus-net/Internal/AsciiFormatter.cs
+++ b/prometheus-net/Internal/AsciiFormatter.cs
@@ -14,7 +14,7 @@ namespace Prometheus.Internal
             var metricFamilys = metrics.ToArray();
             using (var streamWriter = new StreamWriter(destination, Encoding.ASCII))
             {
-                streamWriter.NewLine = "\r";
+                streamWriter.NewLine = "\n";
                 foreach (var metricFamily in metricFamilys)
                 {
                     WriteFamily(streamWriter, metricFamily);

--- a/prometheus-net/Internal/AsciiFormatter.cs
+++ b/prometheus-net/Internal/AsciiFormatter.cs
@@ -14,6 +14,7 @@ namespace Prometheus.Internal
             var metricFamilys = metrics.ToArray();
             using (var streamWriter = new StreamWriter(destination, Encoding.ASCII))
             {
+                streamWriter.NewLine = "\r";
                 foreach (var metricFamily in metricFamilys)
                 {
                     WriteFamily(streamWriter, metricFamily);

--- a/prometheus-net/ScrapeHandler.cs
+++ b/prometheus-net/ScrapeHandler.cs
@@ -12,21 +12,24 @@ namespace Prometheus
         private const string TextContentType = "text/plain; version=0.0.4";
         private const string ProtoAcceptType = "application/vnd.google.protobuf";
 
-        public string ProcessScrapeRequest(
-            IEnumerable<Advanced.DataContracts.MetricFamily> collected, 
-            IEnumerable<string> acceptHeaders, 
+        public void ProcessScrapeRequest(
+            IEnumerable<Advanced.DataContracts.MetricFamily> collected,
+            string contentType,
             Stream outputStream)
         {
-            if (ProtobufAccepted(acceptHeaders))
+            if (contentType == ProtoContentType)
             {
                 ProtoFormatter.Format(outputStream, collected);
-                return ProtoContentType;
             }
             else
             {
                 AsciiFormatter.Format(outputStream, collected);
-                return TextContentType;
             }
+        }
+
+        public static string GetContentType(IEnumerable<string> acceptHeaders)
+        {
+            return ProtobufAccepted(acceptHeaders) ? ProtoContentType : TextContentType;
         }
 
         private static bool ProtobufAccepted(IEnumerable<string> acceptTypesHeader)


### PR DESCRIPTION
My previous commit broke the embedded HTTP server - it was writing the content type header after the body.

Also noticed that the Prometheus server will choke on windows style newlines if you use text format.