### PR TITLE
Use UTF-8 encoding for Text output

### DIFF
--- a/prometheus-net/Internal/AsciiFormatter.cs
+++ b/prometheus-net/Internal/AsciiFormatter.cs
@@ -12,7 +12,7 @@ namespace Prometheus.Internal
         public static void Format(Stream destination, IEnumerable<MetricFamily> metrics)
         {
             var metricFamilys = metrics.ToArray();
-            using (var streamWriter = new StreamWriter(destination, Encoding.ASCII))
+            using (var streamWriter = new StreamWriter(destination, Encoding.UTF8))
             {
                 streamWriter.NewLine = "\n";
                 foreach (var metricFamily in metricFamilys)


### PR DESCRIPTION
I had issues using non-ascii chars in help text and label values. This is fixed by setting the output encoding to _UTF-8_ as  described here: https://prometheus.io/docs/instrumenting/exposition_formats/