### PR TITLE
Update the UTF-8 encoding to never use the byte order mark

### DIFF
--- a/prometheus-net/Internal/AsciiFormatter.cs
+++ b/prometheus-net/Internal/AsciiFormatter.cs
@@ -12,7 +12,12 @@ namespace Prometheus.Internal
         public static void Format(Stream destination, IEnumerable<MetricFamily> metrics)
         {
             var metricFamilys = metrics.ToArray();
-            using (var streamWriter = new StreamWriter(destination, Encoding.UTF8))
+
+            // Use UTF-8 encoding, but provide the flag to ensure the Unicode Byte Order Mark is never
+            //  pre-pended to the output stream. If the BOM exists the push gateway won't understand
+            //  the metric data sent to it.
+            //
+            using (var streamWriter = new StreamWriter(destination, new UTF8Encoding(false)))
             {
                 streamWriter.NewLine = "\n";
                 foreach (var metricFamily in metricFamilys)

--- a/prometheus-net/Internal/AsciiFormatter.cs
+++ b/prometheus-net/Internal/AsciiFormatter.cs
@@ -9,15 +9,16 @@ namespace Prometheus.Internal
 {
     internal class AsciiFormatter
     {
+        private static readonly Encoding Encoding = new UTF8Encoding(false);
+
         public static void Format(Stream destination, IEnumerable<MetricFamily> metrics)
         {
             var metricFamilys = metrics.ToArray();
 
             // Use UTF-8 encoding, but provide the flag to ensure the Unicode Byte Order Mark is never
-            //  pre-pended to the output stream. If the BOM exists the push gateway won't understand
-            //  the metric data sent to it.
+            //  pre-pended to the output stream.
             //
-            using (var streamWriter = new StreamWriter(destination, new UTF8Encoding(false)))
+            using (var streamWriter = new StreamWriter(destination, Encoding))
             {
                 streamWriter.NewLine = "\n";
                 foreach (var metricFamily in metricFamilys)


### PR DESCRIPTION
This is an extension of https://github.com/andrasm/prometheus-net/pull/17, but was discovered while investigating https://github.com/andrasm/prometheus-net/pull/24. Even if PR24 isn't merged, the BOM should probably never be included in the encoded metrics.