### PR TITLE
Threading improvements

### DIFF
--- a/prometheus-net.tests/ThreadSafeDoubleTests.cs
+++ b/prometheus-net.tests/ThreadSafeDoubleTests.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+using Prometheus.Advanced;
+
+namespace Prometheus.Tests
+{
+    [TestFixture]
+    public class ThreadSafeDoubleTests
+    {
+        [Test]
+        public void ThreadSafeDouble_Constructors()
+        {
+            var tsdouble = new ThreadSafeDouble();
+            Assert.AreEqual(0.0, tsdouble.Value);
+
+            tsdouble = new ThreadSafeDouble(1.42);
+            Assert.AreEqual(1.42, tsdouble.Value);
+        }
+
+        [Test]
+        public void ThreadSafeDouble_ValueSet()
+        {
+            var tsdouble = new ThreadSafeDouble();
+            tsdouble.Value = 3.14;
+            Assert.AreEqual(3.14, tsdouble.Value);
+        }
+
+        [Test]
+        public void ThreadSafeDouble_Overrides()
+        {
+            var tsdouble = new ThreadSafeDouble(9.15);
+            var equaltsdouble = new ThreadSafeDouble(9.15);
+            var notequaltsdouble = new ThreadSafeDouble(10.11);
+
+            Assert.AreEqual("9.15", tsdouble.ToString());
+            Assert.IsTrue(tsdouble.Equals(equaltsdouble));
+            Assert.IsFalse(tsdouble.Equals(notequaltsdouble));
+            Assert.IsFalse(tsdouble.Equals(null));
+            Assert.IsTrue(tsdouble.Equals(9.15));
+            Assert.IsFalse(tsdouble.Equals(10.11));
+
+            Assert.AreEqual((9.15).GetHashCode(), tsdouble.GetHashCode());
+        }
+
+        [Test]
+        public void ThreadSafeDouble_Add()
+        {
+            var tsdouble = new ThreadSafeDouble(3.10);
+            tsdouble.Add(0.50);
+            tsdouble.Add(2.00);
+            Assert.AreEqual(5.6, tsdouble.Value);
+        }
+    }
+}

--- a/prometheus-net.tests/ThreadSafeLongTests.cs
+++ b/prometheus-net.tests/ThreadSafeLongTests.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+using Prometheus.Advanced;
+
+namespace Prometheus.Tests
+{
+    [TestFixture]
+    public class ThreadSafeLongTests
+    {
+        [Test]
+        public void ThreadSafeLong_Constructors()
+        {
+            var tsdouble = new ThreadSafeLong();
+            Assert.AreEqual(0L, tsdouble.Value);
+
+            tsdouble = new ThreadSafeLong(1L);
+            Assert.AreEqual(1L, tsdouble.Value);
+        }
+
+        [Test]
+        public void ThreadSafeLong_ValueSet()
+        {
+            var tsdouble = new ThreadSafeLong();
+            tsdouble.Value = 3L;
+            Assert.AreEqual(3L, tsdouble.Value);
+        }
+
+        [Test]
+        public void ThreadSafeLong_Overrides()
+        {
+            var tsdouble = new ThreadSafeLong(9L);
+            var equaltsdouble = new ThreadSafeLong(9L);
+            var notequaltsdouble = new ThreadSafeLong(10L);
+
+            Assert.AreEqual("9", tsdouble.ToString());
+            Assert.IsTrue(tsdouble.Equals(equaltsdouble));
+            Assert.IsFalse(tsdouble.Equals(notequaltsdouble));
+            Assert.IsFalse(tsdouble.Equals(null));
+            Assert.IsTrue(tsdouble.Equals(9L));
+            Assert.IsFalse(tsdouble.Equals(10L));
+
+            Assert.AreEqual((9L).GetHashCode(), tsdouble.GetHashCode());
+        }
+
+        [Test]
+        public void ThreadSafeLong_Add()
+        {
+            var tsdouble = new ThreadSafeLong(3L);
+            tsdouble.Add(2L);
+            tsdouble.Add(5L);
+            Assert.AreEqual(10L, tsdouble.Value);
+        }
+    }
+}

--- a/prometheus-net.tests/prometheus-net.tests.csproj
+++ b/prometheus-net.tests/prometheus-net.tests.csproj
@@ -56,6 +56,8 @@
     <Compile Include="RandomExtensions.cs" />
     <Compile Include="SummaryBenchmarks.cs" />
     <Compile Include="SummaryTests.cs" />
+    <Compile Include="ThreadSafeDoubleTests.cs" />
+    <Compile Include="ThreadSafeLongTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -65,6 +67,9 @@
       <Project>{EE3B50BE-577B-4664-A347-CC737B7D5612}</Project>
       <Name>prometheus-net</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/prometheus-net/Advanced/ThreadSafeDouble.cs
+++ b/prometheus-net/Advanced/ThreadSafeDouble.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading;
+
+namespace Prometheus.Advanced
+{
+    public struct ThreadSafeDouble
+    {
+        private long _value;
+
+        public ThreadSafeDouble(double value)
+        {
+            _value = BitConverter.DoubleToInt64Bits(value);
+        }
+
+        public double Value
+        {
+            get
+            {
+                return BitConverter.Int64BitsToDouble(Interlocked.Read(ref _value));
+            }
+            set
+            {
+                Interlocked.Exchange(ref _value, BitConverter.DoubleToInt64Bits(value));
+            }
+        }
+
+        public void Add(double increment)
+        {
+            while (true)
+            {
+                long initialValue = _value;
+                double computedValue = BitConverter.Int64BitsToDouble(initialValue) + increment;
+
+                //Compare exchange will only set the computed value if it is equal to the expected value
+                //It will always return the the value of _value prior to the exchange (whether it happens or not)
+                //So, only exit the loop if the value was what we expected it to be (initialValue) at the time of exchange otherwise another thread updated and we need to try again.
+                if (initialValue == Interlocked.CompareExchange(ref _value, BitConverter.DoubleToInt64Bits(computedValue), initialValue))
+                    return;
+            }
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ThreadSafeDouble)
+                return Value.Equals(((ThreadSafeDouble)obj).Value);
+
+            return Value.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+    }
+}

--- a/prometheus-net/Advanced/ThreadSafeLong.cs
+++ b/prometheus-net/Advanced/ThreadSafeLong.cs
@@ -1,0 +1,59 @@
+﻿using System.Threading;
+
+namespace Prometheus.Advanced
+{
+    public struct ThreadSafeLong
+    {
+        private long _value;
+
+        public ThreadSafeLong(long value)
+        {
+            _value = value;
+        }
+
+        public long Value
+        {
+            get
+            {
+                return Interlocked.Read(ref _value);
+            }
+            set
+            {
+                Interlocked.Exchange(ref _value, value);
+            }
+        }
+
+        public void Add(long increment)
+        {
+            while (true)
+            {
+                long initialValue = _value;
+                long computedValue = initialValue + increment;
+
+                //Compare exchange will only set the computed value if it is equal to the expected value
+                //It will always return the the value of _value prior to the exchange (whether it happens or not)
+                //So, only exit the loop if the value was what we expected it to be (initialValue) at the time of exchange otherwise another thread updated and we need to try again.
+                if (initialValue == Interlocked.CompareExchange(ref _value, computedValue, initialValue))
+                    return;
+            }
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ThreadSafeLong)
+                return Value.Equals(((ThreadSafeLong)obj).Value);
+
+            return Value.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+    }
+}

--- a/prometheus-net/prometheus-net.csproj
+++ b/prometheus-net/prometheus-net.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Advanced\DotNetStatsCollector.cs" />
     <Compile Include="Advanced\IOnDemandCollector.cs" />
     <Compile Include="Advanced\PerfCounterCollector.cs" />
+    <Compile Include="Advanced\ThreadSafeLong.cs" />
+    <Compile Include="Advanced\ThreadSafeDouble.cs" />
     <Compile Include="Counter.cs" />
     <Compile Include="Advanced\DataContracts.cs" />
     <Compile Include="Gauge.cs" />


### PR DESCRIPTION
Updated the way threading is handled for Counter, Gauge, and Histogram so that locks are not required as Prometheus discourages the use of mutex pattern for client libraries. Adding some missing capabilities recommended by Prometheus.