### PR TITLE
Updating counter to accept 0.

### DIFF
--- a/prometheus-net.tests/MetricsTests.cs
+++ b/prometheus-net.tests/MetricsTests.cs
@@ -34,7 +34,7 @@ namespace Prometheus.Tests
             var counter = Metrics.CreateCounter("name2", "help2", "label1");
             counter.Inc();
             counter.Inc(3.2);
-            Assert.Throws<InvalidOperationException>(() => counter.Inc(0));
+            counter.Inc(0);
             Assert.Throws<InvalidOperationException>(() => counter.Inc(-1));
             counter.Value.ShouldEqual(4.2);
 

--- a/prometheus-net/Counter.cs
+++ b/prometheus-net/Counter.cs
@@ -36,8 +36,9 @@ namespace Prometheus
 
             public void Inc(double increment = 1.0D)
             {
-                if (increment <= 0.0D)
-                    throw new InvalidOperationException("Counter can only go up");
+                //Note: Prometheus recommendations are that this assert > 0. However, there are times your measurement results in a zero and it's easier to have the counter handle this elegantly.
+                if (increment < 0.0D)
+                    throw new InvalidOperationException("Counter cannot go down");
 
                 _value.Add(increment);
             }


### PR DESCRIPTION
Updating counter so that 0 is accepted. Prometheus recommends supporting only greater than 0 but measurements can produce zeros (depending on accuracy) and throwing an exception for this case creates unnecessary burden on a client that this library can just gracefully handle.

My fault for changing this on my last set of changes without thinking about the real consequences for a client.