### PR TITLE
LabelValue escaped for ASCII-format

### DIFF
--- a/prometheus-net.tests/AsciiFormatterTests.cs
+++ b/prometheus-net.tests/AsciiFormatterTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using Prometheus.Advanced.DataContracts;
+using Prometheus.Internal;
+
+namespace Prometheus.Tests
+{
+    public sealed class AsciiFormatterTests
+    {
+        [Test]
+        [TestCase("simple-label-value-1")]
+        [TestCase("with\nlinebreaks")]
+        [TestCase("with\nlinebreaks and \\slashes and quotes \"")]
+        public void family_should_be_formatted_to_one_line(string labelValue)
+        {
+            using (var ms = new MemoryStream())
+            {
+                var metricFamily = new MetricFamily
+                {
+                    name = "family1",
+                    help = "help",
+                    type = MetricType.COUNTER,
+                };
+
+                var metricCounter = new Advanced.DataContracts.Counter { value = 100 };
+                metricFamily.metric.Add(new Metric
+                {
+                    counter = metricCounter,
+                    label = new List<LabelPair>
+                    {
+                        new LabelPair {name = "label1", value = labelValue }
+                    }
+                });
+
+                AsciiFormatter.Format(ms, new[]
+                {
+                    metricFamily
+                });
+
+                using (var sr = new StringReader(Encoding.UTF8.GetString(ms.ToArray())))
+                {
+                    var linesCount = 0;
+                    var line = "";
+                    while ((line = sr.ReadLine()) != null)
+                    {
+                        Console.WriteLine(line);
+                        linesCount += 1;
+                    }
+                    Assert.AreEqual(3, linesCount);
+                }
+            }
+        }
+    }
+}

--- a/prometheus-net.tests/prometheus-net.tests.csproj
+++ b/prometheus-net.tests/prometheus-net.tests.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsciiFormatterTests.cs" />
     <Compile Include="MetricsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuantileStreamTests.cs" />

--- a/prometheus-net/Internal/AsciiFormatter.cs
+++ b/prometheus-net/Internal/AsciiFormatter.cs
@@ -7,7 +7,7 @@ using Prometheus.Advanced.DataContracts;
 
 namespace Prometheus.Internal
 {
-    internal class AsciiFormatter
+    internal static class AsciiFormatter
     {
         // Use UTF-8 encoding, but provide the flag to ensure the Unicode Byte Order Mark is never
         // pre-pended to the output stream.
@@ -83,7 +83,17 @@ namespace Prometheus.Internal
             {
                 return familyName;
             }
-            return string.Format("{0}{{{1}}}", familyName, string.Join(",", labelPairs.Select(l => string.Format("{0}=\"{1}\"", l.name, l.value))));
+            return string.Format(
+                "{0}{{{1}}}", familyName,
+                string.Join(",", labelPairs.Select(l => string.Format("{0}=\"{1}\"", l.name, EscapeValue(l.value)))));
+        }
+
+        private static string EscapeValue(string val)
+        {
+            return val
+                    .Replace("\\", @"\\")
+                    .Replace("\n", @"\n")
+                    .Replace("\"", @"\""");
         }
 
         private static string SimpleValue(string family, double value, IEnumerable<LabelPair> labels, string namePostfix = null)


### PR DESCRIPTION
Hello.

I use pushgateway for pushing metrics and sometimes some of my workers stop pushing metrics. I see in trace output error 500 from push-gateway service. It seems like there is malformed request because of a requirement of escaping newlines, slashes and double quotes is not met in the current code.
