### PR TITLE
Flush metrics when stopping MetricsPusher

### DIFF
--- a/prometheus-net/MetricPusher.cs
+++ b/prometheus-net/MetricPusher.cs
@@ -87,5 +87,11 @@ namespace Prometheus
                 }
             }
         }
+        
+        protected override void StopInner()
+        {
+            // Flush unsaved metrics;  especially important for short jobs which don't have time to push anything at all
+            SendMetrics();
+        }       
     }
 }


### PR DESCRIPTION
This is especially important for short jobs which finish before having a chance to push any metrics.