### PR TITLE
ThreadSafeDouble.ToString() uses invariant culture

### DIFF
--- a/prometheus-net.shared/Advanced/ThreadSafeDouble.cs
+++ b/prometheus-net.shared/Advanced/ThreadSafeDouble.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Threading;
 
 namespace Prometheus.Advanced
@@ -41,7 +42,7 @@ namespace Prometheus.Advanced
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
It used to not specify a culture, resutling in the value being different from machine to machine, potentially breaking things.

This now makes ThreadSafeDouble_Overrides test pass reliably. Fixes #43 