### PR TITLE
tester protobuf-net downgraded to match the rest

### DIFF
--- a/tester/packages.config
+++ b/tester/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />

--- a/tester/tester.csproj
+++ b/tester/tester.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.1.0\lib\net45\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
It used a newer version than the libraries and yet was missing an assembly binding redirect, so it crashed on startup.

Now it uses the same version and does not crash and all is hopefully well. Fixes #42 