### PR TITLE
Tester metric server now uses less common port

### DIFF
--- a/tester/MetricServerTester.cs
+++ b/tester/MetricServerTester.cs
@@ -13,12 +13,12 @@ namespace tester
     {
         public override IMetricServer InitializeMetricHandler()
         {
-            return new MetricServer(hostname: "localhost", port: 1234);
+            return new MetricServer(hostname: "localhost", port: 21881);
         }
 
         public override void OnObservation()
         {
-            var httpRequest = (HttpWebRequest)WebRequest.Create("http://localhost:1234/metrics");
+            var httpRequest = (HttpWebRequest)WebRequest.Create("http://localhost:21881/metrics");
             httpRequest.Method = "GET";
 
             using (var httpResponse = (HttpWebResponse)httpRequest.GetResponse())


### PR DESCRIPTION
It used to use port 1234, which can conflict with other development systems since 1234 is just so easy to type.

Now it uses an arbitrary higher port number, hopefully making life easier for developers with other dev junk also installed and running on their PC.