### PR TITLE
Added Collector.RemoveLabelled()

### DIFF
--- a/prometheus-net.shared/Advanced/Collector.cs
+++ b/prometheus-net.shared/Advanced/Collector.cs
@@ -30,7 +30,15 @@ namespace Prometheus.Advanced
             return GetOrAddLabelled(key);
         }
 
-        private T GetOrAddLabelled(LabelValues key)
+		public void RemoveLabelled(params string[] labelValues)
+		{
+			var key = new LabelValues(LabelNames, labelValues);
+
+			T temp;
+			_labelledMetrics.TryRemove(key, out temp);
+		}
+
+		private T GetOrAddLabelled(LabelValues key)
         {
             return _labelledMetrics.GetOrAdd(key, labels1 =>
             {


### PR DESCRIPTION
This allows removal of labelled child collectors when data with some set of labels is no longer desired to be exported.

Usage is the same as .Labels(), just in the opposite direction.

Closes #40 