### PR TITLE
added .NET 4.6 project to reference proper *.Reactive.* versions

### DIFF
--- a/prometheus-net.NET46.tests/Properties/AssemblyInfo.cs
+++ b/prometheus-net.NET46.tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("prometheus-net.tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("prometheus-net.tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("371acef8-02f3-4a06-9553-6fd7c8c1c403")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/prometheus-net.NET46.tests/app.config
+++ b/prometheus-net.NET46.tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/prometheus-net.NET46.tests/packages.config
+++ b/prometheus-net.NET46.tests/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.0.1" targetFramework="net46" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="Should" version="1.1.20" targetFramework="net46" />
+  <package id="System.Reactive" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net46" />
+</packages>

--- a/prometheus-net.NET46.tests/prometheus-net.NET46.tests.csproj
+++ b/prometheus-net.NET46.tests/prometheus-net.NET46.tests.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Prometheus.Tests</RootNamespace>
+    <AssemblyName>prometheus-net.tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\prometheus-net.shared\prometheus-net.shared.projitems" Label="Shared" />
+  <Import Project="..\prometheus-net.sharedtests\prometheus-net.sharedtests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/prometheus-net.NET46/Properties/AssemblyInfo.cs
+++ b/prometheus-net.NET46/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("prometheus-net")]

--- a/prometheus-net.NET46/app.config
+++ b/prometheus-net.NET46/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/prometheus-net.NET46/packages.config
+++ b/prometheus-net.NET46/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="System.Reactive" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net46" />
+</packages>

--- a/prometheus-net.NET46/prometheus-net.NET46.csproj
+++ b/prometheus-net.NET46/prometheus-net.NET46.csproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Prometheus</RootNamespace>
+    <AssemblyName>prometheus-net</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\build_artifacts\NET46\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\build_artifacts\NET46\Debug\prometheus-net.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\build_artifacts\NET46\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\build_artifacts\NET46\Release\prometheus-net.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\prometheus-net.shared\prometheus-net.shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/prometheus-net.nuspec
+++ b/prometheus-net.nuspec
@@ -10,6 +10,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>.NET client for prometheus.io</description>
     <releaseNotes>
+*
+- Added support for .NET 4.6
 * 1.3.4
 - Added support for .NET 4.5 using System.Reactive 3.1.1.
 - .NET 4.0 support continues to target Rx 2.5
@@ -63,10 +65,15 @@
         <dependency id="protobuf-net" version="2.0.0.668" />
         <dependency id="System.Reactive" version="3.1.1"/>
       </group>
+      <group targetFramework="net46">
+        <dependency id="protobuf-net" version="2.0.0.668" />
+        <dependency id="System.Reactive" version="3.1.1"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
     <file src="build_artifacts\NET40\Release\*.*" target="lib\net40" />
     <file src="build_artifacts\NET45\Release\*.*" target="lib\net45" />
+    <file src="build_artifacts\NET46\Release\*.*" target="lib\net46" />
   </files>
 </package>

--- a/prometheus-net.sln
+++ b/prometheus-net.sln
@@ -23,16 +23,23 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET40.tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET45.tests", "prometheus-net.NET45.tests\prometheus-net.NET45.tests.csproj", "{D866F87B-7088-432C-AE36-10324815A25E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET46", "prometheus-net.NET46\prometheus-net.NET46.csproj", "{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET46.tests", "prometheus-net.NET46.tests\prometheus-net.NET46.tests.csproj", "{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{4010ed45-cbc7-4bf3-94a0-23ae2439d63b}*SharedItemsImports = 13
 		prometheus-net.shared\prometheus-net.shared.projitems*{4d74c8ae-b9dc-47b1-bce2-c70044401a08}*SharedItemsImports = 4
+		prometheus-net.shared\prometheus-net.shared.projitems*{63713f41-0df7-4ead-8a27-0c951dc1f5d0}*SharedItemsImports = 4
 		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{d866f87b-7088-432c-ae36-10324815a25e}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{d866f87b-7088-432c-ae36-10324815a25e}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{e02a4181-e15f-40e7-8fa1-0859a15c5857}*SharedItemsImports = 13
 		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{e5a9406e-1d18-42ed-ba5f-f8cb336fa13a}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{e5a9406e-1d18-42ed-ba5f-f8cb336fa13a}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{ee3b50be-577b-4664-a347-cc737b7d5612}*SharedItemsImports = 4
+		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{eff521ab-2c4d-488b-91e8-79a4b4ce4adf}*SharedItemsImports = 4
+		prometheus-net.shared\prometheus-net.shared.projitems*{eff521ab-2c4d-488b-91e8-79a4b4ce4adf}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +66,14 @@ Global
 		{D866F87B-7088-432C-AE36-10324815A25E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D866F87B-7088-432C-AE36-10324815A25E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D866F87B-7088-432C-AE36-10324815A25E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
There is a version mismatch with *.Reactive.* assemblies when targeting .NET 4.6 (4.5 versions target 3.0.1000 while 4.6 target 3.0.3000).
So to avoid warnings I created a .NET 4.6 version (more or less copy&paste from 4.5).