### PR TITLE
Optional timestamps on metrics

### DIFF
--- a/prometheus-net/Counter.cs
+++ b/prometheus-net/Counter.cs
@@ -52,6 +52,15 @@ namespace Prometheus
             }
         }
 
+        /// <summary>
+        /// Sets the timestamp that Prometheus should use when recording this metric.
+        /// If null, Prometheus will use the current time.
+        /// </summary>
+        public void SetTimestamp(DateTimeOffset? timestamp)
+        {
+            Unlabelled.SetTimestamp(timestamp);
+        }
+
         public double Value
         {
             get { return Unlabelled.Value; }

--- a/prometheus-net/Gauge.cs
+++ b/prometheus-net/Gauge.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using Prometheus.Advanced;
 using Prometheus.Advanced.DataContracts;
+using System;
 
 namespace Prometheus
 {
@@ -100,6 +101,15 @@ namespace Prometheus
         public void Dec(double decrement = 1)
         {
             Unlabelled.Dec(decrement);
+        }
+
+        /// <summary>
+        /// Sets the timestamp that Prometheus should use when recording this metric.
+        /// If null, Prometheus will use the current time.
+        /// </summary>
+        public void SetTimestamp(DateTimeOffset? timestamp)
+        {
+            Unlabelled.SetTimestamp(timestamp);
         }
 
         public double Value

--- a/prometheus-net/Histogram.cs
+++ b/prometheus-net/Histogram.cs
@@ -97,6 +97,15 @@ namespace Prometheus
             }
         }
 
+        /// <summary>
+        /// Sets the timestamp that Prometheus should use when recording this metric.
+        /// If null, Prometheus will use the current time.
+        /// </summary>
+        public void SetTimestamp(DateTimeOffset? timestamp)
+        {
+            Unlabelled.SetTimestamp(timestamp);
+        }
+
         protected override MetricType Type
         {
             get { return MetricType.HISTOGRAM; }

--- a/prometheus-net/Summary.cs
+++ b/prometheus-net/Summary.cs
@@ -305,5 +305,14 @@ namespace Prometheus
         {
             Unlabelled.Observe(val);
         }
+
+        /// <summary>
+        /// Sets the timestamp that Prometheus should use when recording this metric.
+        /// If null, Prometheus will use the current time.
+        /// </summary>
+        public void SetTimestamp(DateTimeOffset? timestamp)
+        {
+            Unlabelled.SetTimestamp(timestamp);
+        }
     }
 }

--- a/tester/Program.cs
+++ b/tester/Program.cs
@@ -26,6 +26,7 @@ namespace tester
             gauge.Inc(3.4);
             gauge.Dec(2.1);
             gauge.Set(5.3);
+            gauge.SetTimestamp(DateTimeOffset.Now.AddDays(-1));
 
             var hist = Metrics.CreateHistogram("myHistogram", "help text", buckets: new[] { 0, 0.2, 0.4, 0.6, 0.8, 0.9 });
             hist.Observe(0.4);
@@ -39,6 +40,7 @@ namespace tester
                 counter.Inc();
                 counter.Labels("GET", "/").Inc(2);
                 gauge.Set(random.NextDouble() + 2);
+                gauge.SetTimestamp(DateTimeOffset.Now.AddDays(-1));
                 hist.Observe(random.NextDouble());
                 summary.Observe(random.NextDouble());
 


### PR DESCRIPTION
You can now optionally specify a custom timestamp to attach to metrics, updated independently of the value.

This is intended mainly to enable export of historical metrics when bootstrapping a Prometheus database from an existing data set.

Did not add a SetTimestamp() on Summary, as I was thinking it might not make sense to report historical Summary data as Summary itself contains a set of time-related logic that might not work for historical data. Did not explore this in depth, so feel free to correct me if I am thinking along the wrong lines on this point.