### PR TITLE
Add .Net Core 1.1 XPlatform support

### DIFF
--- a/prometheus-net.NET40.tests/packages.config
+++ b/prometheus-net.NET40.tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.1" targetFramework="net40" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net40" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net40" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
   <package id="Should" version="1.1.20" targetFramework="net45" />

--- a/prometheus-net.NET40.tests/prometheus-net.NET40.tests.csproj
+++ b/prometheus-net.NET40.tests/prometheus-net.NET40.tests.csproj
@@ -31,13 +31,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5813.39032, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net40\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>

--- a/prometheus-net.NET40/packages.config
+++ b/prometheus-net.NET40/packages.config
@@ -1,5 +1,6 @@
-﻿<packages>
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net40" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="protobuf-net" version="2.1.0" targetFramework="net40" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net40" />
 </packages>

--- a/prometheus-net.NET40/prometheus-net.NET40.csproj
+++ b/prometheus-net.NET40/prometheus-net.NET40.csproj
@@ -33,8 +33,8 @@
     <DocumentationFile>..\build_artifacts\NET40\Release\prometheus-net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="protobuf-net">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/prometheus-net.NET45.tests/packages.config
+++ b/prometheus-net.NET45.tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.1" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />

--- a/prometheus-net.NET45.tests/prometheus-net.NET45.tests.csproj
+++ b/prometheus-net.NET45.tests/prometheus-net.NET45.tests.csproj
@@ -30,13 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net45\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>

--- a/prometheus-net.NET45/packages.config
+++ b/prometheus-net.NET45/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net40" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net452" />

--- a/prometheus-net.NET45/prometheus-net.NET45.csproj
+++ b/prometheus-net.NET45/prometheus-net.NET45.csproj
@@ -35,8 +35,8 @@
     <DocumentationFile>..\build_artifacts\NET45\Release\prometheus-net.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="protobuf-net">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net45\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/prometheus-net.NET46.tests/Properties/AssemblyInfo.cs
+++ b/prometheus-net.NET46.tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("prometheus-net.tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("prometheus-net.tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("371acef8-02f3-4a06-9553-6fd7c8c1c403")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/prometheus-net.NET46.tests/app.config
+++ b/prometheus-net.NET46.tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/prometheus-net.NET46.tests/packages.config
+++ b/prometheus-net.NET46.tests/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.0.1" targetFramework="net46" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="Should" version="1.1.20" targetFramework="net46" />
+  <package id="System.Reactive" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net46" />
+</packages>

--- a/prometheus-net.NET46.tests/packages.config
+++ b/prometheus-net.NET46.tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.1" targetFramework="net46" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="NUnit" version="3.6.1" targetFramework="net46" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net46" />
   <package id="Should" version="1.1.20" targetFramework="net46" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net46" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net46" />

--- a/prometheus-net.NET46.tests/prometheus-net.NET46.tests.csproj
+++ b/prometheus-net.NET46.tests/prometheus-net.NET46.tests.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Prometheus.Tests</RootNamespace>
+    <AssemblyName>prometheus-net.tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\prometheus-net.shared\prometheus-net.shared.projitems" Label="Shared" />
+  <Import Project="..\prometheus-net.sharedtests\prometheus-net.sharedtests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/prometheus-net.NET46.tests/prometheus-net.NET46.tests.csproj
+++ b/prometheus-net.NET46.tests/prometheus-net.NET46.tests.csproj
@@ -31,13 +31,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>

--- a/prometheus-net.NET46/Properties/AssemblyInfo.cs
+++ b/prometheus-net.NET46/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("prometheus-net")]

--- a/prometheus-net.NET46/app.config
+++ b/prometheus-net.NET46/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/prometheus-net.NET46/packages.config
+++ b/prometheus-net.NET46/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="System.Reactive" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net46" />
+  <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net46" />
+</packages>

--- a/prometheus-net.NET46/packages.config
+++ b/prometheus-net.NET46/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net46" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net46" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net46" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net46" />

--- a/prometheus-net.NET46/prometheus-net.NET46.csproj
+++ b/prometheus-net.NET46/prometheus-net.NET46.csproj
@@ -35,9 +35,8 @@
     <DocumentationFile>..\build_artifacts\NET46\Release\prometheus-net.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net451\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/prometheus-net.NET46/prometheus-net.NET46.csproj
+++ b/prometheus-net.NET46/prometheus-net.NET46.csproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Prometheus</RootNamespace>
+    <AssemblyName>prometheus-net</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\build_artifacts\NET46\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\build_artifacts\NET46\Debug\prometheus-net.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\build_artifacts\NET46\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>..\build_artifacts\NET46\Release\prometheus-net.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.1.1\lib\net46\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.PlatformServices.3.1.1\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\prometheus-net.shared\prometheus-net.shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/prometheus-net.NETCORE11.tests/prometheus-net.NETCORE11.tests.csproj
+++ b/prometheus-net.NETCORE11.tests/prometheus-net.NETCORE11.tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>    
+    <TargetFramework>netcoreapp1.1</TargetFramework>    
+    <AssemblyName>prometheus-net.tests</AssemblyName>    
+    <RootNamespace>prometheus-net.tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\prometheus-net.sharedtests\AsciiFormatterTests.cs" Link="AsciiFormatterTests.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\MetricsTests.cs" Link="MetricsTests.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\QuantileStreamTests.cs" Link="QuantileStreamTests.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\RandomExtensions.cs" Link="RandomExtensions.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\SummaryBenchmarks.cs" Link="SummaryBenchmarks.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\SummaryTests.cs" Link="SummaryTests.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\ThreadSafeDoubleTests.cs" Link="ThreadSafeDoubleTests.cs" />
+    <Compile Include="..\prometheus-net.sharedtests\ThreadSafeLongTests.cs" Link="ThreadSafeLongTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="NUnit" Version="3.6.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\prometheus-net.NETCORE11\prometheus-net.NETCORE11.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/prometheus-net.NETCORE11/prometheus-net.NETCORE11.csproj
+++ b/prometheus-net.NETCORE11/prometheus-net.NETCORE11.csproj
@@ -1,0 +1,57 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\Child.cs" Link="Advanced\Child.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\Collector.cs" Link="Advanced\Collector.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\DataContracts.cs" Link="Advanced\DataContracts.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\DefaultCollectorRegistry.cs" Link="Advanced\DefaultCollectorRegistry.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\DotNetStatsCollector.cs" Link="Advanced\DotNetStatsCollector.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\ICollector.cs" Link="Advanced\ICollector.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\ICollectorRegistry.cs" Link="Advanced\ICollectorRegistry.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\IOnDemandCollector.cs" Link="Advanced\IOnDemandCollector.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\MetricFactory.cs" Link="Advanced\MetricFactory.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\PerfCounterCollector.cs" Link="Advanced\PerfCounterCollector.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\ThreadSafeDouble.cs" Link="Advanced\ThreadSafeDouble.cs" />
+    <Compile Include="..\prometheus-net.shared\Advanced\ThreadSafeLong.cs" Link="Advanced\ThreadSafeLong.cs" />
+    <Compile Include="..\prometheus-net.shared\Counter.cs" Link="Counter.cs" />
+    <Compile Include="..\prometheus-net.shared\Gauge.cs" Link="Gauge.cs" />
+    <Compile Include="..\prometheus-net.shared\Histogram.cs" Link="Histogram.cs" />
+    <Compile Include="..\prometheus-net.shared\IMetricServer.cs" Link="IMetricServer.cs" />
+    <Compile Include="..\prometheus-net.shared\Internal\AsciiFormatter.cs" Link="Internal\AsciiFormatter.cs" />
+    <Compile Include="..\prometheus-net.shared\Internal\LabelValues.cs" Link="Internal\LabelValues.cs" />
+    <Compile Include="..\prometheus-net.shared\Internal\ProtoFormatter.cs" Link="Internal\ProtoFormatter.cs" />
+    <Compile Include="..\prometheus-net.shared\MetricHandler.cs" Link="MetricHandler.cs" />
+    <Compile Include="..\prometheus-net.shared\MetricPusher.cs" Link="MetricPusher.cs" />
+    <Compile Include="..\prometheus-net.shared\Metrics.cs" Link="Metrics.cs" />
+    <Compile Include="..\prometheus-net.shared\MetricServer.cs" Link="MetricServer.cs" />
+    <Compile Include="..\prometheus-net.shared\ScrapeHandler.cs" Link="ScrapeHandler.cs" />
+    <Compile Include="..\prometheus-net.shared\Summary.cs" Link="Summary.cs" />
+    <Compile Include="..\prometheus-net.shared\SummaryImpl\QuantileComparer.cs" Link="SummaryImpl\QuantileComparer.cs" />
+    <Compile Include="..\prometheus-net.shared\SummaryImpl\QuantileEpsilonPair.cs" Link="SummaryImpl\QuantileEpsilonPair.cs" />
+    <Compile Include="..\prometheus-net.shared\SummaryImpl\QuantileStream.cs" Link="SummaryImpl\QuantileStream.cs" />
+    <Compile Include="..\prometheus-net.shared\SummaryImpl\Sample.cs" Link="SummaryImpl\Sample.cs" />
+    <Compile Include="..\prometheus-net.shared\SummaryImpl\SampleBuffer.cs" Link="SummaryImpl\SampleBuffer.cs" />
+    <Compile Include="..\prometheus-net.shared\SummaryImpl\SampleStream.cs" Link="SummaryImpl\SampleStream.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Internal\" />
+    <Folder Include="Advanced\" />
+    <Folder Include="SummaryImpl\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net" Version="2.1.0" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/prometheus-net.nuspec
+++ b/prometheus-net.nuspec
@@ -10,6 +10,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>.NET client for prometheus.io</description>
     <releaseNotes>
+*
+- Added support for .NET 4.6
 * 1.3.4
 - Added support for .NET 4.5 using System.Reactive 3.1.1.
 - .NET 4.0 support continues to target Rx 2.5
@@ -63,10 +65,15 @@
         <dependency id="protobuf-net" version="2.0.0.668" />
         <dependency id="System.Reactive" version="3.1.1"/>
       </group>
+      <group targetFramework="net46">
+        <dependency id="protobuf-net" version="2.0.0.668" />
+        <dependency id="System.Reactive" version="3.1.1"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
     <file src="build_artifacts\NET40\Release\*.*" target="lib\net40" />
     <file src="build_artifacts\NET45\Release\*.*" target="lib\net45" />
+    <file src="build_artifacts\NET46\Release\*.*" target="lib\net46" />
   </files>
 </package>

--- a/prometheus-net.shared/Advanced/Collector.cs
+++ b/prometheus-net.shared/Advanced/Collector.cs
@@ -30,7 +30,15 @@ namespace Prometheus.Advanced
             return GetOrAddLabelled(key);
         }
 
-        private T GetOrAddLabelled(LabelValues key)
+		public void RemoveLabelled(params string[] labelValues)
+		{
+			var key = new LabelValues(LabelNames, labelValues);
+
+			T temp;
+			_labelledMetrics.TryRemove(key, out temp);
+		}
+
+		private T GetOrAddLabelled(LabelValues key)
         {
             return _labelledMetrics.GetOrAdd(key, labels1 =>
             {

--- a/prometheus-net.shared/Advanced/DataContracts.cs
+++ b/prometheus-net.shared/Advanced/DataContracts.cs
@@ -10,8 +10,12 @@
 // Generated from: prometheus.proto
 namespace Prometheus.Advanced.DataContracts
 {
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"LabelPair")]
-  public partial class LabelPair : global::ProtoBuf.IExtensible
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"LabelPair")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"LabelPair")]
+#endif
+    public partial class LabelPair : global::ProtoBuf.IExtensible
   {
     public LabelPair() {}
     
@@ -35,8 +39,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Gauge")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"Gauge")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Gauge")]
+#endif
   public partial class Gauge : global::ProtoBuf.IExtensible
   {
     public Gauge() {}
@@ -53,8 +61,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Counter")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"Counter")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Counter")]
+#endif
   public partial class Counter : global::ProtoBuf.IExtensible
   {
     public Counter() {}
@@ -71,8 +83,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Quantile")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"Quantile")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Quantile")]
+#endif
   public partial class Quantile : global::ProtoBuf.IExtensible
   {
     public Quantile() {}
@@ -97,8 +113,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Summary")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"Summary")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Summary")]
+#endif
   public partial class Summary : global::ProtoBuf.IExtensible
   {
     public Summary() {}
@@ -130,8 +150,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Untyped")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name = @"Untyped")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Untyped")]
+#endif
   public partial class Untyped : global::ProtoBuf.IExtensible
   {
     public Untyped() {}
@@ -148,8 +172,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Histogram")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name = @"Histogram")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Histogram")]
+#endif
   public partial class Histogram : global::ProtoBuf.IExtensible
   {
     public Histogram() {}
@@ -181,8 +209,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Bucket")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"Bucket")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Bucket")]
+#endif
   public partial class Bucket : global::ProtoBuf.IExtensible
   {
     public Bucket() {}
@@ -207,8 +239,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"MetricFamily")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"MetricFamily")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"MetricFamily")]
+#endif
   public partial class Metric : global::ProtoBuf.IExtensible
   {
     public Metric() {}
@@ -273,8 +309,12 @@ namespace Prometheus.Advanced.DataContracts
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
   }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"MetricFamily")]
+
+#if (NETCOREAPP1_1)
+    [global::ProtoBuf.ProtoContract(Name=@"MetricFamily")]
+#else
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"MetricFamily")]
+#endif
   public partial class MetricFamily : global::ProtoBuf.IExtensible
   {
     public MetricFamily() {}

--- a/prometheus-net.shared/Advanced/DotNetStatsCollector.cs
+++ b/prometheus-net.shared/Advanced/DotNetStatsCollector.cs
@@ -17,7 +17,9 @@ namespace Prometheus.Advanced
         private Gauge _workingSet;
         private Gauge _privateMemorySize;
         private Counter _cpuTotal;
+#if (!NETCOREAPP1_1)
         private Gauge _openHandles;
+#endif
         private Gauge _startTime;
         private Gauge _numThreads;
         private Gauge _pid;
@@ -44,7 +46,9 @@ namespace Prometheus.Advanced
             _virtualMemorySize = Metrics.CreateGauge("process_windows_virtual_bytes", "Process virtual memory size");
             _workingSet = Metrics.CreateGauge("process_windows_working_set", "Process working set");
             _privateMemorySize = Metrics.CreateGauge("process_windows_private_bytes", "Process private memory size");
+#if (!NETCOREAPP1_1)
             _openHandles = Metrics.CreateGauge("process_windows_open_handles", "Number of open handles");
+#endif
             _numThreads = Metrics.CreateGauge("process_windows_num_threads", "Total number of threads");
             _pid = Metrics.CreateGauge("process_windows_processid", "Process ID");
 
@@ -74,7 +78,9 @@ namespace Prometheus.Advanced
                 _workingSet.Set(_process.WorkingSet64);
                 _privateMemorySize.Set(_process.PrivateMemorySize64);
                 _cpuTotal.Inc(_process.TotalProcessorTime.TotalSeconds - _cpuTotal.Value);
+#if (!NETCOREAPP1_1)
                 _openHandles.Set(_process.HandleCount);
+#endif
                 _numThreads.Set(_process.Threads.Count);
             }
             catch (Exception)

--- a/prometheus-net.shared/Advanced/PerfCounterCollector.cs
+++ b/prometheus-net.shared/Advanced/PerfCounterCollector.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 
 namespace Prometheus.Advanced
 {
+#if (!NETCOREAPP1_1)
     /// <summary>
     /// Collects metrics on standard Performance Counters
     /// </summary>
@@ -102,4 +103,5 @@ namespace Prometheus.Advanced
             }
         }
     }
+#endif
 }

--- a/prometheus-net.shared/MetricPusher.cs
+++ b/prometheus-net.shared/MetricPusher.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if (!NETCOREAPP1_1)
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -95,3 +96,4 @@ namespace Prometheus
         }       
     }
 }
+#endif

--- a/prometheus-net.shared/MetricServer.cs
+++ b/prometheus-net.shared/MetricServer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if (!NETCOREAPP1_1)
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
@@ -76,3 +77,4 @@ namespace Prometheus
         }
     }
 }
+#endif

--- a/prometheus-net.sharedtests/MetricsTests.cs
+++ b/prometheus-net.sharedtests/MetricsTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if (!NETCOREAPP1_1)
+using System;
 using System.Linq;
 using NUnit.Framework;
 using Prometheus.Advanced;
@@ -280,3 +281,4 @@ namespace Prometheus.Tests
         }
     }
 }
+#endif

--- a/prometheus-net.sharedtests/SummaryBenchmarks.cs
+++ b/prometheus-net.sharedtests/SummaryBenchmarks.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using NUnit.Framework.Compatibility;
 using Prometheus.Advanced.DataContracts;
 using Prometheus.Internal;
 

--- a/prometheus-net.sln
+++ b/prometheus-net.sln
@@ -23,16 +23,23 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET40.tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET45.tests", "prometheus-net.NET45.tests\prometheus-net.NET45.tests.csproj", "{D866F87B-7088-432C-AE36-10324815A25E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET46", "prometheus-net.NET46\prometheus-net.NET46.csproj", "{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET46.tests", "prometheus-net.NET46.tests\prometheus-net.NET46.tests.csproj", "{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{4010ed45-cbc7-4bf3-94a0-23ae2439d63b}*SharedItemsImports = 13
 		prometheus-net.shared\prometheus-net.shared.projitems*{4d74c8ae-b9dc-47b1-bce2-c70044401a08}*SharedItemsImports = 4
+		prometheus-net.shared\prometheus-net.shared.projitems*{63713f41-0df7-4ead-8a27-0c951dc1f5d0}*SharedItemsImports = 4
 		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{d866f87b-7088-432c-ae36-10324815a25e}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{d866f87b-7088-432c-ae36-10324815a25e}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{e02a4181-e15f-40e7-8fa1-0859a15c5857}*SharedItemsImports = 13
 		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{e5a9406e-1d18-42ed-ba5f-f8cb336fa13a}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{e5a9406e-1d18-42ed-ba5f-f8cb336fa13a}*SharedItemsImports = 4
 		prometheus-net.shared\prometheus-net.shared.projitems*{ee3b50be-577b-4664-a347-cc737b7d5612}*SharedItemsImports = 4
+		prometheus-net.sharedtests\prometheus-net.sharedtests.projitems*{eff521ab-2c4d-488b-91e8-79a4b4ce4adf}*SharedItemsImports = 4
+		prometheus-net.shared\prometheus-net.shared.projitems*{eff521ab-2c4d-488b-91e8-79a4b4ce4adf}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +66,14 @@ Global
 		{D866F87B-7088-432C-AE36-10324815A25E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D866F87B-7088-432C-AE36-10324815A25E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D866F87B-7088-432C-AE36-10324815A25E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/prometheus-net.sln
+++ b/prometheus-net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tester", "tester\tester.csproj", "{C0212A44-AE68-4315-BC20-3B8BB40A3F98}"
 EndProject
@@ -26,6 +26,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET46", "prometheus-net.NET46\prometheus-net.NET46.csproj", "{63713F41-0DF7-4EAD-8A27-0C951DC1F5D0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NET46.tests", "prometheus-net.NET46.tests\prometheus-net.NET46.tests.csproj", "{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "prometheus-net.NETCORE11", "prometheus-net.NETCORE11\prometheus-net.NETCORE11.csproj", "{94C83714-BDDC-4AC8-A372-4330D707D381}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "prometheus-net.NETCORE11.tests", "prometheus-net.NETCORE11.tests\prometheus-net.NETCORE11.tests.csproj", "{1072B16C-D12C-4A69-BEC3-D50A3597B0A1}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -74,6 +78,14 @@ Global
 		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFF521AB-2C4D-488B-91E8-79A4B4CE4ADF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94C83714-BDDC-4AC8-A372-4330D707D381}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94C83714-BDDC-4AC8-A372-4330D707D381}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94C83714-BDDC-4AC8-A372-4330D707D381}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94C83714-BDDC-4AC8-A372-4330D707D381}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1072B16C-D12C-4A69-BEC3-D50A3597B0A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1072B16C-D12C-4A69-BEC3-D50A3597B0A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1072B16C-D12C-4A69-BEC3-D50A3597B0A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1072B16C-D12C-4A69-BEC3-D50A3597B0A1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tester/packages.config
+++ b/tester/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.1.0" targetFramework="net45" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />

--- a/tester/tester.csproj
+++ b/tester/tester.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="protobuf-net, Version=2.1.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.1.0\lib\net45\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Added .Net Core 1.1 Support. Since tests are not discoverable by Visual Studio 2017 yet, they have not been   executed, but they build OK.

MetricsServer and MetricsPusher are escaped with the compiler flag "NETCOREAPP1_1" so in this PR you need to implement  a "Metrics" endpoint sometning like this:

## startup.cs

    ...
    public static Lazy<DotNetStatsCollector> LazyDotNetStatsCollector = new Lazy<DotNetStatsCollector>(() => new DotNetStatsCollector());
    ...
    public void ConfigureServices(IServiceCollection services)
        {
    ...
            services.AddMvc(options =>
            {
                options.OutputFormatters.Add(new ProtobufOutputFormatter());
            });
    ...
        }
    ...
    public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
        {
    ...
            LazyDotNetStatsCollector.Value.RegisterMetrics();
    ...
        }

 ## MetricsController
        [HttpGet]
        public async Task<IActionResult> Get()
        {
            var registry = DefaultCollectorRegistry.Instance;
            var acceptHeaders = Request.Headers["Accept"];
            var contentType = ScrapeHandler.GetContentType(acceptHeaders);
            Response.ContentType = contentType;
            ObjectResult result;
            const string ProtoContentType = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";

            Startup.LazyDotNetStatsCollector.Value.UpdateMetrics();
                using (var ms = new MemoryStream())
                {
                    ScrapeHandler.ProcessScrapeRequest(registry.CollectAll(), contentType, ms);
                    if (contentType == ProtoContentType)
                    {
                        if (ms.CanSeek) ms.Seek(0, SeekOrigin.Begin);
                        result = new ObjectResult(ms.ToArray());
                    }
                    else
                    {
                        var txt = Encoding.UTF8.GetString(ms.ToArray());
                        result = new OkObjectResult(txt);
                    }
                }
            return result;
        }

## ProtobufOutputFormatter 

    public class ProtobufOutputFormatter : OutputFormatter
    {
        static readonly MediaTypeHeaderValue ProtoMediaType = MediaTypeHeaderValue.Parse("application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited");
        private static readonly Lazy<RuntimeTypeModel> model = new Lazy<RuntimeTypeModel>(CreateTypeModel);

        public string ContentType { get; } = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";

        public static RuntimeTypeModel Model => model.Value;

        public ProtobufOutputFormatter()
        {
            SupportedMediaTypes.Add(ProtoMediaType);
        }

        private static RuntimeTypeModel CreateTypeModel()
        {
            var typeModel = TypeModel.Create();
            typeModel.UseImplicitZeroDefaults = false;
            return typeModel;
        }

        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
        {
            var response = context.HttpContext.Response;
            return Task.FromResult(response);
        }
    }