### PR TITLE
Update protobuf-net to 2.2.1

### DIFF
--- a/prometheus-net/prometheus-net.csproj
+++ b/prometheus-net/prometheus-net.csproj
@@ -85,7 +85,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="2.1.0" />
+    <PackageReference Include="protobuf-net" Version="2.2.1" />
   </ItemGroup>
 
 </Project>

--- a/tester/packages.config
+++ b/tester/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.2.1" targetFramework="net45" />
   <package id="System.Reactive" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />

--- a/tester/tester.csproj
+++ b/tester/tester.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="protobuf-net, Version=2.2.1.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.2.1\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -76,7 +75,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\prometheus-net\prometheus-net.csproj">


### PR DESCRIPTION
Hi there

The Tester console project does not start work due to an outdated protobuf-net package - it's been fixed by updating to latest version of the package.

FYI: I haven't been able to run the unittests - downloaded NUnit console runner (3.6.1) but it errors out on me due nunit dependencies. See attached transcript of nunit console run for details

[nunit_testrun_err.txt](https://github.com/andrasm/prometheus-net/files/1124435/nunit_testrun_err.txt)

Best regards