### PR TITLE
Fix ThreadSafeDouble.Add()

### DIFF
--- a/prometheus-net/Advanced/ThreadSafeDouble.cs
+++ b/prometheus-net/Advanced/ThreadSafeDouble.cs
@@ -29,7 +29,8 @@ namespace Prometheus.Advanced
         {
             while (true)
             {
-                double computedValue = Value + increment;
+                long initialValue = Interlocked.Read(ref _value);
+                double computedValue = BitConverter.Int64BitsToDouble(initialValue) + increment;
 
                 //Compare exchange will only set the computed value if it is equal to the expected value
                 //It will always return the the value of _value prior to the exchange (whether it happens or not)

--- a/prometheus-net/Advanced/ThreadSafeDouble.cs
+++ b/prometheus-net/Advanced/ThreadSafeDouble.cs
@@ -29,8 +29,7 @@ namespace Prometheus.Advanced
         {
             while (true)
             {
-                long initialValue = _value;
-                double computedValue = BitConverter.Int64BitsToDouble(initialValue) + increment;
+                double computedValue = Value + increment;
 
                 //Compare exchange will only set the computed value if it is equal to the expected value
                 //It will always return the the value of _value prior to the exchange (whether it happens or not)


### PR DESCRIPTION
Since reading\writing of `long` is not thread safe (https://stackoverflow.com/a/5209632/4963622), reading of `_value` should be wrapped in `Interlocked.Read()` - https://msdn.microsoft.com/en-us/library/system.threading.interlocked.read(v=vs.110).aspx#Remarks