### PR TITLE
Performance enhancements to collecting labeled metrics

### DIFF
--- a/prometheus-net/Advanced/Collector.cs
+++ b/prometheus-net/Advanced/Collector.cs
@@ -39,15 +39,19 @@ namespace Prometheus.Advanced
 		}
 
 		private T GetOrAddLabelled(LabelValues key)
-        {
-            return _labelledMetrics.GetOrAdd(key, labels1 =>
-            {
-                var child = new T();
-                child.Init(this, labels1);
-                return child;
-            });
-        }
+		{
+		    T val;
+		    if (_labelledMetrics.TryGetValue(key, out val))
+		        return val;
 
+		    val = new T();
+		    val.Init(this, key);
+		    _labelledMetrics.TryAdd(key, val);
+		    key.InitWireLabels();
+		    
+		    return val;
+        }
+        
         protected T Unlabelled
         {
             get { return _unlabelledLazy.Value; }

--- a/prometheus-net/Advanced/Collector.cs
+++ b/prometheus-net/Advanced/Collector.cs
@@ -19,7 +19,7 @@ namespace Prometheus.Advanced
         readonly static Regex MetricName = new Regex(METRIC_NAME_RE);
         readonly static Regex LabelNameRegex = new Regex("^[a-zA-Z_:][a-zA-Z0-9_:]*$");
         readonly static Regex ReservedLabelRegex = new Regex("^__.*$");
-        readonly static LabelValues EmptyLabelValues = new LabelValues(new string[0], new string[0]);
+        readonly static LabelValues EmptyLabelValues = LabelValues.Empty;
         // ReSharper restore StaticFieldInGenericType
 
         protected abstract MetricType Type { get; }

--- a/prometheus-net/Internal/LabelValues.cs
+++ b/prometheus-net/Internal/LabelValues.cs
@@ -12,7 +12,10 @@ namespace Prometheus.Internal
         private readonly string[] _names;
         
         internal List<LabelPair> WireLabels; 
-        internal static readonly LabelValues Empty = new LabelValues(new string[0], new string[0]);
+        internal static readonly LabelValues Empty = new LabelValues(new string[0], new string[0])
+        {
+            WireLabels = new List<LabelPair>()
+        };
 
         public LabelValues(string[] names, string[] values)
         {
@@ -41,7 +44,8 @@ namespace Prometheus.Internal
             if (other._values.Length != _values.Length) return false;
             for (int i = 0; i < _values.Length; i++)
             {
-                if ((_values[i]) != other._values[i]) return false;
+                if (!string.Equals(_values[i], other._values[i], StringComparison.Ordinal)) 
+                    return false;
             }
 
             return true;


### PR DESCRIPTION
- Replaced the use of `ConcurrentDictionary<T, K>.GetOrAdd` in `Collector.GetOrAddLabelled` as the function was allocating a closure
- Made `LabelValues` a struct to avoid heap allocations
- `LabelValues` precomputes it's hash code now- as this never changes, it doesn't make sense to re-compute it. Saves CPU when repeatedly recording metrics with the same labels.
- `LabelValues.LabelValues` is only initialised once per unique combination of label values, this saves CPU + memory when repeatedly recording metrics with the same labels.

Changes allow recording metrics with labels to be ~3x faster and allocate ~12x less memory

|       Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
------------------- |---------  |---------- |---------- |------- |---------- |
 RecordLabelsNew | 321.5 ns | 9.348 ns | 13.99 ns | 0.0176 |      56 B |
 RecordLabelsOld | 1.169 us | 0.0204 us | 0.0306 us | 0.1888 |     600 B |

